### PR TITLE
ci: Update workflows to use ubuntu-latest for job runners

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   pre-commit:
     name: "Frappe Linter"
-    runs-on: ["self-hosted", "python"]
+    runs-on: ubuntu-latest
     container:
       image: alpine:latest # latest used here for simplicity, not recommended
     defaults:

--- a/.github/workflows/vulnerable_dependency_check.yml
+++ b/.github/workflows/vulnerable_dependency_check.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   deps-vulnerable-check:
     name: Vulnerable Dependency Check
-    runs-on: ["self-hosted", "python"]
+    runs-on: ubuntu-latest
     container:
       image: python:latest
     defaults:


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows` configuration files to update the environment used for running jobs and a subproject commit update. The most important changes are as follows:

Workflow environment updates:

* [`.github/workflows/linters.yml`](diffhunk://#diff-c94729f5aa1afabfd250d3a929cdc840199d92facd4c83fcbc37b661d784d4acL16-R16): Changed the `runs-on` parameter from `["self-hosted", "python"]` to `ubuntu-latest` for the "Frappe Linter" job.
* [`.github/workflows/vulnerable_dependency_check.yml`](diffhunk://#diff-a8262a29ff02068a209969128488c5e574b998bb23be4ed91b4e4e421e843828L17-R17): Changed the `runs-on` parameter from `["self-hosted", "python"]` to `ubuntu-latest` for the "Vulnerable Dependency Check" job.

Subproject commit update:

* [`.frappe-semgrep`](diffhunk://#diff-bbcd1826ae8fe0659e722ca4368cd884d9ed3262ffe7f700d049bc449b5f12c4R1): Updated the subproject commit to `d01e207b1fc6e9cd400fc465db3ef55507bb4c1e`.