### PR TITLE
Workflow: Linters: Use global npm to install prettier

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -23,7 +23,7 @@ jobs:
       - name: fix tar dependency in alpine container image
         run: |
           apk --no-cache add tar nodejs npm python3 git bash py3-pip
-          apk --no-cache add prettier --repository=https://dl-cdn.alpinelinux.org/alpine/edge/testing
+          npm install -g prettier
           # check python modules installed versions
           python3 -m pip freeze --local
           pip install pre-commit --break-system-packages


### PR DESCRIPTION
This pull request updates the way Prettier is installed in the linter workflow for better compatibility and reliability. Instead of installing Prettier via the Alpine testing repository, it is now installed globally using npm.

Dependency installation update:

* Changed Prettier installation in `.github/workflows/linters.yml` from using the Alpine testing repository to using `npm install -g prettier` for improved reliability and compatibility.

Fixes
-----
```
ERROR: unable to select packages:
  prettier (no such package):
    required by: world[prettier]
Error: Process completed with exit code 1.
```