### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/iamimmanuelraj/block_administrator/security/code-scanning/1](https://github.com/iamimmanuelraj/block_administrator/security/code-scanning/1)

To fix the problem, we should explicitly add a `permissions` block to the workflow. The most secure minimal default for CI jobs is usually `contents: read`, which only allows read access to the repository code and metadata. This can be achieved by adding a `permissions:` entry either at the workflow (top) level or for the relevant job(s). Since this workflow only seems to check out code, run tests, and does not act on issues or pull requests, no elevated permissions are required. 

The single best way to implement this is to insert at the root level, immediately after the `name` field and before the `on:` block, the following:

```yaml
permissions:
  contents: read
```

This way, all jobs inherit this least-privilege setting, and we avoid accidental privilege escalation in future edits as well.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
